### PR TITLE
chore(workflows): change node version of deploy job and cache global npm modules

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 17.3.0
+          cache: 'npm'
 
       - name: Cache node modules
         id: cache-npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,12 +14,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
-    strategy:
-      matrix:
-        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 17.3.0
 
       - name: Cache node modules
         id: cache-npm


### PR DESCRIPTION
This PR sets the node version of the deploy job to 17.3.0 which is supported by the aws-cdk and also caches the global cdk installation.