### PR TITLE
chore: add unit tests to ConfigDialogService

### DIFF
--- a/webapp/src/app/service/config-dialog-service.spec.ts
+++ b/webapp/src/app/service/config-dialog-service.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import { ConfigDialogService } from './config-dialog-service';
+
+describe('ConfigDialogService', () => {
+  let service: ConfigDialogService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ConfigDialogService],
+    });
+    service = TestBed.inject(ConfigDialogService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should have isOpen$ observable', () => {
+    expect(service.isOpen$).toBeDefined();
+  });
+
+  it('should emit true when openDialog is called', (done) => {
+    service.isOpen$.subscribe((value) => {
+      expect(value).toBe(true);
+      done();
+    });
+    service.openDialog();
+  });
+
+  it('should emit false when closeDialog is called', (done) => {
+    service.isOpen$.subscribe((value) => {
+      expect(value).toBe(false);
+      done();
+    });
+    service.closeDialog();
+  });
+
+  it('should emit values in sequence when toggled', () => {
+    const emittedValues: boolean[] = [];
+
+    service.isOpen$.subscribe((value) => {
+      emittedValues.push(value);
+    });
+
+    service.openDialog();
+    service.closeDialog();
+    service.openDialog();
+
+    expect(emittedValues).toEqual([true, false, true]);
+  });
+});


### PR DESCRIPTION
Add unit tests for ConfigDialogService to verify the service initialization, isOpen$ observable behavior, and dialog open/close state management. Tests cover the basic creation, observable emission on openDialog/closeDialog calls, and sequential state transitions.

