### PR TITLE
test 9

### DIFF
--- a/webapp/src/app/service/config-dialog-service.spec.ts
+++ b/webapp/src/app/service/config-dialog-service.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed } from '@angular/core/testing';
+import { ConfigDialogService } from './config-dialog-service';
+
+describe('ConfigDialogService', () => {
+  let service: ConfigDialogService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ConfigDialogService],
+    });
+    service = TestBed.inject(ConfigDialogService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should have isOpen$ observable', () => {
+    expect(service.isOpen$).toBeTruthy();
+  });
+
+  it('should emit true when openDialog is called', (done) => {
+    service.isOpen$.subscribe((value) => {
+      expect(value).toBe(true);
+      done();
+    });
+    service.openDialog();
+  });
+
+  it('should emit false when closeDialog is called', (done) => {
+    service.isOpen$.subscribe((value) => {
+      expect(value).toBe(false);
+      done();
+    });
+    service.closeDialog();
+  });
+
+  it('should emit correct sequence of values', () => {
+    const emissions: boolean[] = [];
+    service.isOpen$.subscribe((value) => emissions.push(value));
+
+    service.openDialog();
+    service.closeDialog();
+    service.openDialog();
+
+    expect(emissions).toEqual([true, false, true]);
+  });
+});


### PR DESCRIPTION
Add unit tests for ConfigDialogService to verify the dialog state management functionality. Tests cover service creation, observable behavior, and the open/close dialog state transitions.

